### PR TITLE
Use embedded workbench to run tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,32 +93,22 @@ You can define an arbitrary number of drag items.
 Testing
 -------
 
-1. In a virtualenv, run
+In a virtualenv, run
 
 ```bash
-$ (cd .../xblock-sdk/; pip install -r requirements.txt)
-$ (cd .../xblock-drag-and-drop-v2/; pip install -r tests/requirements.txt)
+$ cd .../xblock-drag-and-drop-v2/
+$ pip install -r tests/requirements.txt
 ```
 
-2. In the xblock-sdk repository, create the following configuration
-file in `workbench/settings_drag_and_drop_v2.py`
-
-```python
-from settings import *
-
-INSTALLED_APPS += ('drag_and_drop_v2',)
-DATABASES['default']['NAME'] = 'workbench.db'
-```
-
-3. Run this to sync the database before starting the workbench
-(answering no to the superuser question is ok):
+To run the tests, from the xblock-drag-and-drop-v2 repository root:
 
 ```bash
-$ ../xblock-sdk/manage.py syncdb --settings=workbench.settings_drag_and_drop_v2
+$ tests/manage.py test --rednose
 ```
 
-4. To run the tests, from the xblock-drag-and-drop-v2 repository root:
+To include coverage report (although selenium tends to crash with
+segmentation faults when collection test coverage):
 
 ```bash
-$ DJANGO_SETTINGS_MODULE="workbench.settings_drag_and_drop_v2" nosetests --rednose --verbose --with-cover --cover-package=drag_and_drop_v2 --with-django
+$ tests/manage.py test --rednose --with-cover --cover-package=drag_and_drop_v2
 ```

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Manage.py file for xblock-drag-and-drop-v2"""
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,27 @@
-mock
-nose
-coverage
-rednose
-nose-parameterized
+bok_choy==0.3.2
+cookiecutter==0.7.1
+coverage==3.7.1
+diff-cover==0.7.2
+Django==1.4.16
+django_nose==1.2
+fs==0.5.0
+lazy==1.2
+lxml==3.4.1
+mock==1.0.1
+nose==1.3.4
+nose-parameterized==0.3.5
+pep8==1.5.7
+pylint==0.28
+pypng==0.0.17
+rednose==0.4.1
+requests==2.4.3
+selenium==2.44.0
+simplejson==3.6.5
+webob==1.4
+
+-e git+https://github.com/open-craft/XBlock.git@3ece535ee8e095f21de2f8b28cc720145749f0d6#egg=XBlock
+-e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
+-e git+https://github.com/pmitros/django-pyfs.git@514607d78535fd80bfd23184cd292ee5799b500d#egg=djpyfs
+-e git+https://github.com/open-craft/xblock-sdk.git@39b00c58931664ce29bb4b38df827fe237a69613#egg=xblock-sdk
 
 -e .

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,39 @@
+DEBUG = True
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'workbench',
+    'sample_xblocks.basic',
+    'django_nose',
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'drag_and_drop_v2.db'
+    }
+}
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
+    }
+}
+
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.eggs.Loader',
+)
+
+ROOT_URLCONF = 'urls'
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+STATIC_ROOT = ''
+STATIC_URL = '/static/'
+
+WORKBENCH = {'reset_state_on_restart': False}

--- a/tests/test_drag_and_drop_v2.py
+++ b/tests/test_drag_and_drop_v2.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import json
 import unittest
@@ -13,7 +14,10 @@ from nose.tools import (
     assert_in
 )
 
+from tests.utils import load_resource
+
 import drag_and_drop_v2
+
 
 
 # Silence too verbose Django logging
@@ -204,12 +208,10 @@ class TestDragAndDropHtmlData(BaseDragAndDropAjaxFixture, unittest.TestCase):
     FINAL_FEEDBACK = "Final <b>Feed</b>"
 
     def initial_data(self):
-        with open('tests/data/test_html_data.json') as f:
-            return json.load(f)
+        return json.loads(load_resource('data/test_html_data.json'))
 
     def get_data_response(self):
-        with open('tests/data/test_get_html_data.json') as f:
-            return json.load(f)
+        return json.loads(load_resource('data/test_get_html_data.json'))
 
 
 class TestDragAndDropPlainData(BaseDragAndDropAjaxFixture, unittest.TestCase):
@@ -225,12 +227,10 @@ class TestDragAndDropPlainData(BaseDragAndDropAjaxFixture, unittest.TestCase):
     FINAL_FEEDBACK = "Final Feed"
 
     def initial_data(self):
-        with open('tests/data/test_data.json') as f:
-            return json.load(f)
+        return json.loads(load_resource('data/test_data.json'))
 
     def get_data_response(self):
-        with open('tests/data/test_get_data.json') as f:
-            return json.load(f)
+        return json.loads(load_resource('data/test_get_data.json'))
 
 def test_ajax_solve_and_reset():
     block = make_block()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls import include, url
+
+urlpatterns = [
+    url(r'^', include('workbench.urls')),
+]


### PR DESCRIPTION
Instead of having to checkout the `xblock-sdk` repository
and set `xblock-drag-and-drop-v2` to run within it,
the `xblock-sdk` repository has been added to the test requirements.

A barebone django app that loads the workbench to run integration tests
has been created inside the tests folder.

All test dependencies have been explicitly pinned in `test/requirements.txt`.

Assuming you have Firefox installed, running the tests should be
as simple as `pip install -r tests/requirements.txt` in a fresh virtual
environment and then `tests/manage.py test`.
