### PR TITLE
Fix minor merge typo in zone edit js template

### DIFF
--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -59,19 +59,19 @@
                     class="align-select"
                     aria-describedby="zone-align-description">
                 <option value="" 
-                    {{#ifeq align ""}}selected{{/ifeq}}>
+                    {{#ifeq zone.align ""}}selected{{/ifeq}}>
                     {{i18n "none"}}
                 </option>
                 <option value="left" 
-                    {{#ifeq align "left"}}selected{{/ifeq}}>
+                    {{#ifeq zone.align "left"}}selected{{/ifeq}}>
                     {{i18n "left"}}
                 </option>
                 <option value="center" 
-                    {{#ifeq align "center"}}selected{{/ifeq}}>
+                    {{#ifeq zone.align "center"}}selected{{/ifeq}}>
                     {{i18n "center"}}
                 </option>
                 <option value="right"
-                    {{#ifeq align "right"}}selected{{/ifeq}}>
+                    {{#ifeq zone.align "right"}}selected{{/ifeq}}>
                     {{i18n "right"}}
                 </option>
             </select>


### PR DESCRIPTION
@bradenmacdonald The fix for the St Gallen branch (OC-1360) was minor, just a difference in template syntax.