### PR TITLE
[OC-1883] Miscellaneous fixes

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -396,6 +396,10 @@
     font-size: 14px;
 }
 
+.xblock--drag-and-drop .popup .popup-content img {
+    max-width: 100%;
+}
+
 .xblock--drag-and-drop .popup .close-feedback-popup-button {
     cursor: pointer;
     margin-top: 8px;

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -6,9 +6,6 @@
 
     <section class="drag-builder">
         <div class="tab feedback-tab">
-            <p class="tab-content">
-                {% trans "Note: do not edit the problem if students have already completed it. Delete the problem and create a new one." %}
-            </p>
 
             <section class="tab-content">
                 <form class="feedback-form">
@@ -71,12 +68,12 @@
                     </div>
 
                     <label class="h4">
-                        <span>{% trans "Introductory Feedback" %}</span>
+                        <span>{% trans "Introductory feedback" %}</span>
                         <textarea class="intro-feedback">{{ self.data.feedback.start }}</textarea>
                     </label>
 
                     <label class="h4">
-                        <span>{% trans "Final Feedback" %}</span>
+                        <span>{% trans "Final feedback" %}</span>
                         <textarea class="final-feedback">{{ self.data.feedback.finish }}</textarea>
                     </label>
                 </form>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -142,13 +142,13 @@
         </div>
         <div class="row">
             <label class="h4">
-                <span>{{i18n "Success Feedback"}}</span>
+                <span>{{i18n "Success feedback"}}</span>
                 <textarea class="success-feedback">{{ feedback.correct }}</textarea>
             </label>
         </div>
         <div class="row">
             <label class="h4">
-                <span>{{i18n "Error Feedback"}}</span>
+                <span>{{i18n "Error feedback"}}</span>
                 <textarea class="error-feedback">{{ feedback.incorrect }}</textarea>
             </label>
         </div>

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -304,11 +304,11 @@ msgid ""
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid "Success Feedback"
+msgid "Success feedback"
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid "Error Feedback"
+msgid "Error feedback"
 msgstr ""
 
 #: templates/html/js_templates.html
@@ -340,11 +340,11 @@ msgid ""
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Introductory Feedback"
+msgid "Introductory feedback"
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Final Feedback"
+msgid "Final feedback"
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -366,12 +366,12 @@ msgstr ""
 "évén ïf thé ïmägé dïd nöt löäd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт #"
 
 #: templates/html/js_templates.html
-msgid "Success Feedback"
-msgstr "Süççéss Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
+msgid "Success feedback"
+msgstr "Süççéss féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
 
 #: templates/html/js_templates.html
-msgid "Error Feedback"
-msgstr "Érrör Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
+msgid "Error feedback"
+msgstr "Érrör féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
 
 #: templates/html/js_templates.html
 msgid "Show advanced settings"
@@ -413,12 +413,12 @@ msgstr ""
 "thé prößlém änd çréäté ä néw öné. Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Introductory Feedback"
-msgstr "Ìntrödüçtörý Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+msgid "Introductory feedback"
+msgstr "Ìntrödüçtörý féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Final Feedback"
-msgstr "Fïnäl Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
+msgid "Final feedback"
+msgstr "Fïnäl féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
 
 #: templates/html/drag_and_drop_edit.html
 msgid "Background URL"


### PR DESCRIPTION
## Description

* Consistent capitalization in the Studio editor
* Remove dangerous recommendation to delete from the top of the editor
* Stop large images from overflowing feedback popups in Studio

## Dependencies

*None*

## JIRA

- [OC-1883](https://openedx.atlassian.net/browse/OC-1883)

## Sandbox URLs

- [Studio](http://studio-dndv2-pr96.opencraft.hosting/container/block-v1:test+tt101+run+type@vertical+block@vertical_drag_and_drop_v2_e7e5618f0eae)

## Latest commit

- e5eca5a *(updated 2016-09-15)*

## Testing instructions

1. Go to the preconfigured block on [Studio](http://studio-dndv2-pr96.opencraft.hosting/container/block-v1:test+tt101+run+type@vertical+block@vertical_drag_and_drop_v2_e7e5618f0eae), and log in as `staff@example.com`.
2. Edit the block.
3. Notice that there is no message on the top advising authors to delete the block.
4. Read through all items, pressing "Continue" until the last page, and notice that all item headers (such as "Introductory feedback", or "Success feedback") follow the same capitalization convention.
5. Notice that the sucess feedbacks on this instance contain a 700x700 placeholder image.  Close the edit box, and place an item correctly.  The image should be properly contained in the popup, as seen in the screenshot below.

## Screenshots

1. What a large image should look like in a success feedback popup, in Studio or the LMS:
![screenshot1](https://cloud.githubusercontent.com/assets/759355/18535221/a73159ca-7ac8-11e6-90f1-d3b9bb6366bf.png)

2. Consistent capitalization, in Studio:
![screenshot2](https://cloud.githubusercontent.com/assets/759355/18535222/a749a340-7ac8-11e6-8230-a10a96a983da.png)

3. The removed message from the top of the edit form:
![screenshot3](https://cloud.githubusercontent.com/assets/759355/18535223/a749c7da-7ac8-11e6-9aed-eff7935aff46.png)