### PR TITLE
Don't delete misplaced items on final attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "sh install_test_deps.sh"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.9.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.10.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "sh install_test_deps.sh"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.10.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.11.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+Version 2.0.10 (2016-09-22)
+---------------------------
+
+* ([#97](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/97)) Added "item" field to item.dropped event
+* ([#101](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/101)) Implement "show answer" button
+* ([#103](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/103)) Miscellaneous UI fixes
+* ([#105](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/105)) Correct an issue with background image selection
+
 Version 2.0.9 (2016-09-01)
 --------------------------
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Version 2.0.11 (2016-10-03)
+---------------------------
+
+* ([#106](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/106)) Don't delete misplaced items on final attempt
+
 Version 2.0.10 (2016-09-22)
 ---------------------------
 

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -403,7 +403,9 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
 
         misplaced_items = []
         for item_id in misplaced_ids:
-            del self.item_state[item_id]
+            # Don't delete misplaced item states on the final attempt.
+            if self.attempts_remain:
+                del self.item_state[item_id]
             misplaced_items.append(self._get_item_definition(int(item_id)))
 
         feedback_msgs = [FeedbackMessage(item['feedback']['incorrect'], None) for item in misplaced_items]

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -94,7 +94,7 @@
                            type="text"
                            aria-describedby="background-url-{{id_suffix}}" />
                     </label>
-                    <button class="btn">{% trans "Change background" %}</button>
+                    <button type="button" class="btn">{% trans "Change background" %}</button>
                     <div id="background-url-description-{{id_suffix}}" class="form-help">
                         {% trans "For example, 'http://example.com/background.png' or '/static/background.png'." %}
                     </div>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.9',
+    version='2.0.10',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.10',
+    version='2.0.11',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -139,6 +139,36 @@ class AssessmentInteractionTest(
         for item_id in misplaced_items:
             self.assert_reverted_item(item_id)
 
+    def test_misplaced_items_not_returned_to_bank_on_final_attempt(self):
+        """
+        Test items placed on incorrect zones are not returned to item bank
+        after submitting solution on the final attempt, and remain placed after
+        subsequently refreshing the page.
+        """
+        self.place_item(0, TOP_ZONE_ID, action_key=Keys.RETURN)
+
+        # Reach final attempt
+        for _ in xrange(self.MAX_ATTEMPTS-1):
+            self.click_submit()
+
+        # Place incorrect item on final attempt
+        self.place_item(1, TOP_ZONE_ID, action_key=Keys.RETURN)
+        self.click_submit()
+
+        # Incorrect item remains placed
+        def _assert_placed(item_id, zone_title):
+            item = self._get_placed_item_by_value(item_id)
+            item_description = item.find_element_by_css_selector('.sr')
+            self.assertEqual(item_description.text, 'Placed in: {}'.format(zone_title))
+
+        _assert_placed(1, TOP_ZONE_TITLE)
+
+        # Refresh the page
+        self._page = self.go_to_page(self.PAGE_TITLE)
+
+        # Incorrect item remains placed after refresh
+        _assert_placed(1, TOP_ZONE_TITLE)
+
     def test_max_attempts_reached_submit_and_reset_disabled(self):
         """
         Test "Submit" and "Reset" buttons are disabled when no more attempts remaining

--- a/tests/unit/test_advanced.py
+++ b/tests/unit/test_advanced.py
@@ -404,6 +404,21 @@ class AssessmentModeFixture(BaseDragAndDropAjaxFixture):
         expected_message = self._make_feedback_message(self.FINAL_FEEDBACK)
         self.assertIn(expected_message, res[self.OVERALL_FEEDBACK_KEY])
 
+    def test_do_attempt_does_not_delete_misplaced_items_at_last_attempt(self):
+        """
+        Upon submitting the final attempt, test that misplaced items are not
+        deleted from the item state.
+        """
+        self._set_final_attempt()
+        misplaced_ids = self._submit_incorrect_solution()
+
+        self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+        self.assertFalse(self.block.attempts_remain)  # precondition check
+
+        for i in misplaced_ids:
+            self.assertIn(str(i), self.block.item_state.keys())
+
     def test_get_user_state_does_not_include_correctness(self):
         self._submit_complete_solution()
         original_item_state = self.block.item_state


### PR DESCRIPTION
## Description

In assessment mode, don't delete misplaced items from the user's state when handling the final attempt.

This is a server-side change to match what Javascript already did.  In other words, upon submitting the final attempt, misplaced items were already left on the board.  However, since the corresponding state was deleted server-side, upon refreshing the page the items were returned to the bank.

## Dependencies

*None*

## JIRA

*None*

## Sandbox URLs

- [LMS](http://dndv2-sol-1998.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2/)
- [Studio](http://studio-dndv2-sol-1998.opencraft.hosting/container/block-v1:test+tt101+run+type@vertical+block@drag_and_drop_v2)

## Latest commit

- 479b8dd *(updated 2016-09-27)*

## Testing instructions

1. Go to the [pre-deployed DnDv2 instance](http://dndv2-sol-1998.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2/) on the LMS, and log in as `staff@example.com`.
2. Click on `Staff Debug Info`, and `Delete Student State` for the `staff@example.com` user.
3. Close the debug info window, and drag a single item into its correct zone (for instance, "Goes to the Top" to the top zone).
4. Click `Submit` twice, so that you only have one attempt left.
5. Drag an item into an incorrect zone (for instance, drag "I don't belong anywhere" to the bottom zone).
6. Click `Submit`.
7. Close the incorrect answer popup.
8. Refresh the page.
9. Notice that even though you have no attempts left, the wrongly placed item is still there.

## Screenshots

### Wronly placed item is still there after refreshing the page.

![screenshot](https://cloud.githubusercontent.com/assets/759355/18894195/00ed7ad8-84e8-11e6-952a-718a9dec6606.png)
