### PR TITLE
Fix SVG loading issues in IE11

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -15,6 +15,7 @@
     overflow: hidden;
     pointer-events: none;
     z-index: -1;
+    visibility: hidden;
 }
 
 .xblock--drag-and-drop .initial-load-spinner {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -638,6 +638,7 @@ function DragAndDropTemplates(configuration) {
         // image to 100%, so that it doesn't expand the container.
         if (ctx.drag_container_max_width === null) {
             target_img_style.maxWidth = '100%';
+            item_bank_properties.style = {display: 'none'};
         } else {
             drag_container_style.maxWidth = ctx.drag_container_max_width + 'px';
         }

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -979,6 +979,14 @@ function DragAndDropBlock(runtime, element, configuration) {
         var promise = $.Deferred();
         var img = new Image();
         img.addEventListener("load", function() {
+            if (img.width == 0 || img.height == 0) {
+                // Workaround for IE11 issue with SVG images
+                document.body.appendChild(img);
+                var width = img.offsetWidth;
+                var height = img.offsetHeight;
+                document.body.removeChild(img);
+                img.width = width, img.height = height;
+            }
             if (img.width > 0 && img.height > 0) {
                 promise.resolve(img);
             } else {

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -178,6 +178,9 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         self.browser.execute_script('$(".wrapper-workbench").css("margin-right", "-{}px")'.format(40 + scrollbar_width))
         # And reduce the wasted space around our XBlock in the workbench:
         self.browser.execute_script('return $(".workbench .preview").css("margin", "0")')
+        # Dynamically adjusting styles causes available screen width to change, but does not always emit
+        # resize events consistently, so emit resize manually to make sure the block adapts to the new size.
+        self.browser.execute_script('$(window).resize()')
 
     def _check_mobile_container_size(self):
         """ Verify that the drag-container tightly fits into the available space. """


### PR DESCRIPTION
Image.height and Image.width returns 0 for SVGs loaded in JavaScript on
IE11, this uses a klunky workaround to get the height and width