### PR TITLE
[MCKIN-6342] Fix intermittent issue in iOS mobile app

### DIFF
--- a/drag_and_drop_v2_new/public/css/drag_and_drop_mcka.css
+++ b/drag_and_drop_v2_new/public/css/drag_and_drop_mcka.css
@@ -3,9 +3,16 @@
 /* Every rule in this file MUST include the selector ".themed-xblock" to avoid affecting the old drag and drop v2 */
 
 /* Bugfixes that we will merge into the upstream app soon: */
-.target-img-wrapper {
-    user-select: none;
+.themed-xblock.xblock--drag-and-drop .drag-container,
+.themed-xblock.xblock--drag-and-drop .target-img-wrapper
+{
+    /* Disallow selection on mobile, which causes problematic menu popups during drag and drop*/
+    -webkit-touch-callout: none;
     -webkit-user-select: none;
+     -khtml-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
 }
 
 /*///////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes an odd bug on iOS:

On mobile, we want users to be able to scroll the screen (vertically) and the box of draggable items (horizontally), so we have an `ontouchstart` handler that doesn't call `event.preventDefault()` and which instead allows the default behavior (e.g. scrolling) but also waits half a second and then starts to drag the item if the user hasn't scrolled.

Unfortunately, because we can't call `preventDefault()`, the default behavior of "touch and hold to select text" is also still active, and it can sometimes cause problems as a text selection occurs at the same time as the drag and drop.

Testing instructions:
* Remove (pip uninstall) any drag and drop v2 installation you may have on the solutions devstack.
* Install drag and drop 2 with the `v3-temporary-branch` onto your solutions devstack. (Don't check out this fix's branch yet, because you want to first reproduce the issue)
* In a course, in the advanced settings, add `drag-and-drop-v2-new` and then add a new subsection + unit containing a drag and drop block.
* Add to that XBlock a new draggable using https://placehold.it/100x80 as the image URL - this will make testing easier by expanding the size of the draggable items container.
* View that new unit from the mobile app (ask me for details on the OC- ticket if needed)
* In the XCode iOS simulator, "tap" and hold in this area, highlighted in green: 
![how-to-reproduce](https://user-images.githubusercontent.com/945577/32864185-ecc31bdc-ca12-11e7-8b4f-c794f0a201b8.png)
    You should be clicking just below the actual draggable item, so you won't trigger a drag-and-drop, but you will trigger the selection bug: ![selection-bug](https://user-images.githubusercontent.com/945577/32864195-f6c687d6-ca12-11e7-8099-cfc339643fc9.png)

   I have found this to be the most reliable way to reproduce the issue locally. Once you do this once, you may then see the bug every time you try to drag the draggables normally from that point on.
* Checkout this branch, with the fix
* In the app, navigate back to the course outline, then go back into the XBlock (this is sufficient to load the new CSS with the fix - make sure you see a new request for the CSS files in the LMS log).
* Try reproducing the bug again - it should not occur