### PR TITLE
[MCKIN-6342] Prevent user selection of actions toolbar.

### DIFF
--- a/drag_and_drop_v2_new/public/css/drag_and_drop_mcka.css
+++ b/drag_and_drop_v2_new/public/css/drag_and_drop_mcka.css
@@ -4,7 +4,8 @@
 
 /* Bugfixes that we will merge into the upstream app soon: */
 .themed-xblock.xblock--drag-and-drop .drag-container,
-.themed-xblock.xblock--drag-and-drop .target-img-wrapper
+.themed-xblock.xblock--drag-and-drop .target-img-wrapper,
+.themed-xblock.xblock--drag-and-drop .actions-toolbar
 {
     /* Disallow selection on mobile, which causes problematic menu popups during drag and drop*/
     -webkit-touch-callout: none;


### PR DESCRIPTION
On mobile user selection can occur spontaneously when the user tries to drag an item, causing issues and interfering with the drag.

Similar issues were already fixed in https://github.com/open-craft/xblock-drag-and-drop-v2/pull/17, but undesired selection would still occur in some cases.

**JIRA ticket**: [MCKIN-6342](https://edx-wiki.atlassian.net/browse/MCKIN-6342)

**Testing instructions**:

Follow instructions on https://github.com/open-craft/xblock-drag-and-drop-v2/pull/17.
I found the easiest way to reproduce the bug is to tap and hold in the action toolbar area, left of the reset button. If you trigger the selection this way first, it seems to almost consistently occur when you try to drag an item from the item bank later.